### PR TITLE
1 setup ws foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
-# credit-card-tx-api
-Mocked credit card transactions Websocket API for experimental/educational purposes
+# Credit Card Transactions Websocket API
+Mocked credit card transactions Websocket API for experimental/educational purposes.
+
+## Overview
+This project is a simple credit card transactions Websocket API. It is a mock of a real API that would be used to get credit card transactions,
+useful for experimental/educational purposes, such as testing and developing ML models for fraud detection.
+
+### Channels
+The websocketAPI has two channels:
+- `heartbeat`: for checking if the connection is alive
+- `transactions`: for getting credit card transactions in realtime
+
+## Local Setup
+Run `make run` to start the API locally.
+The API will be available at `ws://localhost:9999/v1`.
+
+## API Reference
+
+
+
+## Subscribing to Channels
+
+To subscribe to a channel, you need to send a message to the server with the following format:
+
+```json
+{
+  "method": "subscribe",
+  "params": {
+    "channel": "trade"
+  }
+}
+```
+### Transactions Response
+
+```json
+{
+  "channel": "transactions",
+  "data": [
+    {
+      "id": "11df919988c134d97bbff2678eb68e22",
+      "timestamp": "2024-01-01T00:00:00Z",
+      "cc_number": "4473593503484549",
+      "category": "Grocery",
+      "amount_usd_cents": 10000,
+      "latitude": 37.774929,
+      "longitude": -122.419418,
+      "country_iso": "US",
+      "city": "San Francisco",
+    }
+  ]
+}
+```
+
+### Heartbeat
+
+```json
+{
+  "channel": "heartbeat",
+  "data": {
+    "status": "ok"
+  }
+}
+```
+
+

--- a/txapi/Cargo.toml
+++ b/txapi/Cargo.toml
@@ -4,3 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+tokio = { version = "1", features = ["full"] }
+axum = { version = "0.8", features = ["ws"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+futures = "0.3"

--- a/txapi/Cargo.toml
+++ b/txapi/Cargo.toml
@@ -9,3 +9,6 @@ axum = { version = "0.8", features = ["ws"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures = "0.3"
+chrono = "0.4.39"
+uuid = { version = "1.13.1", features = ["v4"] }
+rand = "0.9.0"

--- a/txapi/src/lib.rs
+++ b/txapi/src/lib.rs
@@ -1,3 +1,1 @@
-pub fn hello(name: &str) {
-    println!("Hello, {}!", name);
-}
+pub mod models;

--- a/txapi/src/main.rs
+++ b/txapi/src/main.rs
@@ -1,5 +1,136 @@
-use txapi::hello;
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        State,
+    },
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+use futures::{
+    sink::SinkExt,
+    stream::{SplitSink, SplitStream, StreamExt},
+};
+use std::sync::{Arc, Mutex};
+use tokio::sync::broadcast;
+use txapi::models::{HeartbeatData, SubscribeReq, Transaction, TxResponse};
 
-fn main() {
-    hello("world");
+#[derive(Clone)]
+struct AppState {
+    tx: Arc<Mutex<broadcast::Sender<String>>>,
+}
+
+#[tokio::main]
+async fn main() {
+    // Create a channel for broadcasting messages.  Holds 16 messages in the buffer.
+    let (tx, _) = broadcast::channel(16);
+    let app_state = AppState {
+        tx: Arc::new(Mutex::new(tx)),
+    };
+
+    let app = Router::new()
+        .route("/v1", get(websocket_handler))
+        .with_state(app_state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:9999")
+        .await
+        .unwrap();
+
+    println!("Listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn websocket_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    ws.on_upgrade(|socket| websocket(socket, state))
+}
+
+async fn websocket(socket: WebSocket, state: AppState) {
+    let (sender, receiver) = socket.split();
+    let tx = state.tx.lock().unwrap().clone();
+
+    let rx = tx.subscribe();
+
+    // Spawn a task to handle sending messages.
+    tokio::spawn(write(sender, tx, rx));
+
+    // Spawn a task to handle receiving messages.
+    tokio::spawn(read(receiver, state));
+}
+
+async fn read(mut receiver: SplitStream<WebSocket>, state: AppState) {
+    while let Some(Ok(msg)) = receiver.next().await {
+        if let Message::Text(text) = msg {
+            println!("Received: {}", text);
+
+            // Handle the subscription request
+            if let Ok(req) = serde_json::from_str::<SubscribeReq>(&text) {
+                if req.method == "subscribe" && req.params.channel == "transactions" {
+                    // Send some mock transactions.  In a real application, you'd
+                    // fetch these from a database or other source.
+                    let transactions = vec![
+                        Transaction {
+                            id: "11df919988c134d97bbff2678eb68e22".to_string(),
+                            timestamp: "2024-01-01T00:00:00Z".to_string(),
+                            cc_number: "4473593503484549".to_string(),
+                            category: "Grocery".to_string(),
+                            amount_usd_cents: 10000,
+                            latitude: 37.774929,
+                            longitude: -122.419418,
+                            country_iso: "US".to_string(),
+                            city: "San Francisco".to_string(),
+                        },
+                        // Add more mock transactions as needed
+                    ];
+
+                    let response = TxResponse::Transactions { data: transactions };
+
+                    if let Ok(serialized_response) = serde_json::to_string(&response) {
+                        let _ = state.tx.lock().unwrap().send(serialized_response);
+                    }
+                } else if req.method == "subscribe" && req.params.channel == "heartbeat" {
+                    let heartbeat = TxResponse::Heartbeat {
+                        data: HeartbeatData {
+                            status: "ok".to_string(),
+                        },
+                    };
+
+                    if let Ok(serialized_response) = serde_json::to_string(&heartbeat) {
+                        let _ = state.tx.lock().unwrap().send(serialized_response);
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn write(
+    mut sender: SplitSink<WebSocket, Message>,
+    _tx: broadcast::Sender<String>,
+    mut rx: broadcast::Receiver<String>,
+) {
+    loop {
+        tokio::select! {
+            msg = rx.recv() => {
+                match msg {
+                    Ok(msg) => {
+                        if sender.send(Message::Text(msg.into())).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        // If the receiver has lagged behind, it will have missed messages.
+                        // You might want to handle this case, e.g., by sending a special
+                        // "resync" message or closing the connection.  Here, we just continue.
+                        continue;
+                    }
+                    Err(_) => {
+                        break;
+                    }
+                }
+            }
+        }
+    }
 }

--- a/txapi/src/main.rs
+++ b/txapi/src/main.rs
@@ -20,7 +20,6 @@ struct AppState {
 
 #[tokio::main]
 async fn main() {
-    // create a channel for broadcasting messages that holds 16 messages in the buffer.
     let app_state = AppState {};
 
     let app = Router::new()

--- a/txapi/src/main.rs
+++ b/txapi/src/main.rs
@@ -11,7 +11,7 @@ use futures::{
     sink::SinkExt,
     stream::{SplitSink, SplitStream, StreamExt},
 };
-use txapi::models::{ChannelMsg, Heartbeat, Transaction};
+use txapi::models::{ChannelMsg, Heartbeat, Request, Transaction};
 
 #[derive(Clone)]
 struct AppState {
@@ -45,62 +45,99 @@ async fn websocket_handler(
 async fn websocket(socket: WebSocket, _state: AppState) {
     let (sender, receiver) = socket.split();
 
-    // Spawn tasks to handle sending and receiving messages
-    let write_task = tokio::spawn(write(sender));
-    let read_task = tokio::spawn(read(receiver));
+    // Update channel type to use Request directly
+    let (tx, rx) = tokio::sync::mpsc::channel(1);
 
-    // Wait for either task to finish
+    let write_task = tokio::spawn(write(sender, rx));
+    let read_task = tokio::spawn(read(receiver, tx));
+
     tokio::select! {
         _ = write_task => {},
         _ = read_task => {},
     }
 }
 
-async fn read(mut receiver: SplitStream<WebSocket>) {
+async fn read(mut receiver: SplitStream<WebSocket>, tx: tokio::sync::mpsc::Sender<Request>) {
     while let Some(Ok(msg)) = receiver.next().await {
         if let Message::Text(text) = msg {
             println!("Received: {}", text);
-            // TODO: handle subscription requests
+            if let Ok(request) = serde_json::from_str::<Request>(&text) {
+                let _ = tx.send(request).await;
+            } else {
+                println!("Failed to parse message: {}", text);
+            }
         }
     }
 }
 
-async fn write(mut sender: SplitSink<WebSocket, Message>) {
-    // send initial subscription ack
-    let ack = ChannelMsg::Heartbeat {
-        data: Heartbeat {
-            status: "subscribed to transactions".to_string(),
-        },
-    };
-    if let Ok(serialized) = serde_json::to_string(&ack) {
-        if sender.send(Message::Text(serialized.into())).await.is_err() {
-            return;
-        }
-    }
+async fn write(
+    mut sender: SplitSink<WebSocket, Message>,
+    mut rx: tokio::sync::mpsc::Receiver<Request>,
+) {
+    let mut subscribed_channels: Vec<String> = Vec::new();
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
 
-    // start transaction loop
-    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
     loop {
-        let _ = interval.tick().await;
-        let transaction = Transaction {
-            id: uuid::Uuid::new_v4().to_string().replace("-", ""),
-            timestamp: chrono::Utc::now().to_rfc3339(),
-            cc_number: "4473593503484549".to_string(),
-            category: "Grocery".to_string(),
-            amount_usd_cents: rand::random::<u64>() % 10000,
-            latitude: 37.774929,
-            longitude: -122.419418,
-            country_iso: "US".to_string(),
-            city: "San Francisco".to_string(),
-        };
+        tokio::select! {
+            Some(request) = rx.recv() => {
+                match request {
+                    Request::Subscribe { params } => {
+                        if !subscribed_channels.contains(&params.channel) {
+                            subscribed_channels.push(params.channel.clone());
+                        }
+                        let status = format!("Successfully subscribed to {} channel", params.channel);
+                        let ack = ChannelMsg::Heartbeat {
+                            data: Heartbeat {
+                                status,
+                            },
+                        };
+                        if let Ok(serialized) = serde_json::to_string(&ack) {
+                            if sender.send(Message::Text(serialized.into())).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                    Request::Unsubscribe { params } => {
+                        subscribed_channels.retain(|c| c != &params.channel);
+                        let status = format!("Successfully unsubscribed from {} channel", params.channel);
+                        let ack = ChannelMsg::Heartbeat {
+                            data: Heartbeat {
+                                status,
+                            },
+                        };
+                        if let Ok(serialized) = serde_json::to_string(&ack) {
+                            if sender.send(Message::Text(serialized.into())).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
 
-        let msg = ChannelMsg::Transactions {
-            data: vec![transaction],
-        };
+            _ = interval.tick() => {
+                if subscribed_channels.contains(&"transactions".to_string()) {
+                    let transaction = Transaction {
+                        id: uuid::Uuid::new_v4().to_string().replace("-", ""),
+                        timestamp: chrono::Utc::now().to_rfc3339(),
+                        cc_number: "4473593503484549".to_string(),
+                        category: "Grocery".to_string(),
+                        amount_usd_cents: rand::random::<u64>() % 10000,
+                        latitude: 37.774929,
+                        longitude: -122.419418,
+                        country_iso: "US".to_string(),
+                        city: "San Francisco".to_string(),
+                    };
 
-        if let Ok(serialized) = serde_json::to_string(&msg) {
-            if sender.send(Message::Text(serialized.into())).await.is_err() {
-                break;
+                    let msg = ChannelMsg::Transactions {
+                        data: vec![transaction],
+                    };
+
+                    if let Ok(serialized) = serde_json::to_string(&msg) {
+                        if sender.send(Message::Text(serialized.into())).await.is_err() {
+                            break;
+                        }
+                    }
+                }
             }
         }
     }

--- a/txapi/src/main.rs
+++ b/txapi/src/main.rs
@@ -9,21 +9,23 @@ use axum::{
 };
 use futures::{
     sink::SinkExt,
-    stream::{SplitSink, SplitStream, StreamExt},
+    stream::{select_all, SplitSink, SplitStream, StreamExt},
     Stream,
 };
-use std::pin::Pin;
 use std::time::Duration;
-use txapi::models::{ChannelMsg, Heartbeat, Request, Transaction};
+use tokio::sync::broadcast;
+use txapi::models::{ChannelMsg, Heartbeat, Transaction, WsMessage};
 
 #[derive(Clone)]
 struct AppState {
-    // nothing for now...
+    broadcaster_tx: broadcast::Sender<Transaction>,
 }
 
 #[tokio::main]
 async fn main() {
-    let app_state = AppState {};
+    let app_state = AppState {
+        broadcaster_tx: init_broadcaster().await,
+    };
 
     let app = Router::new()
         .route("/v1", get(websocket_handler))
@@ -44,14 +46,14 @@ async fn websocket_handler(
     ws.on_upgrade(|socket| websocket(socket, state))
 }
 
-async fn websocket(socket: WebSocket, _state: AppState) {
-    let (sender, receiver) = socket.split();
+async fn websocket(socket: WebSocket, state: AppState) {
+    let (ws_sink, ws_stream) = socket.split();
 
-    // Update channel type to use Request directly
-    let (tx, rx) = tokio::sync::mpsc::channel(1);
+    // channel for messages between the websocket and the server
+    let (msg_tx, msg_rx) = tokio::sync::mpsc::channel(1);
 
-    let write_task = tokio::spawn(write(sender, rx));
-    let read_task = tokio::spawn(read(receiver, tx));
+    let write_task = tokio::spawn(write(ws_sink, msg_rx, state));
+    let read_task = tokio::spawn(read(ws_stream, msg_tx));
 
     tokio::select! {
         _ = write_task => {},
@@ -59,39 +61,77 @@ async fn websocket(socket: WebSocket, _state: AppState) {
     }
 }
 
-async fn read(mut receiver: SplitStream<WebSocket>, tx: tokio::sync::mpsc::Sender<Request>) {
-    while let Some(Ok(msg)) = receiver.next().await {
+async fn init_broadcaster() -> broadcast::Sender<Transaction> {
+    let buffer_size = 100;
+    let buffer_size = std::env::var("BROADCAST_BUFFER_SIZE")
+        .map(|s| s.parse::<usize>().unwrap_or(buffer_size))
+        .unwrap_or(buffer_size);
+
+    let (broadcaster_tx, _) = broadcast::channel(buffer_size);
+    let broadcaster_tx_clone = broadcaster_tx.clone();
+
+    let mock_tx_stream = stream_tx_from_mocks();
+    // add more streams here (ex. kafka, mongodb, etc.)
+
+    // combine all streams into one
+    let mut broadcast_stream = select_all(vec![
+        Box::pin(mock_tx_stream),
+        // add other streams here...
+    ]);
+
+    // apawn the transaction stream processor
+    tokio::spawn(async move {
+        while let Some(transaction) = broadcast_stream.next().await {
+            // ignore send errors (occurs when no receivers)
+            // TODO: handle this gracefully
+            let _ = broadcaster_tx_clone.send(transaction);
+        }
+    });
+    broadcaster_tx
+}
+
+async fn read(mut ws_stream: SplitStream<WebSocket>, msg_tx: tokio::sync::mpsc::Sender<WsMessage>) {
+    while let Some(Ok(msg)) = ws_stream.next().await {
         if let Message::Text(text) = msg {
             println!("Received: {}", text);
-            if let Ok(request) = serde_json::from_str::<Request>(&text) {
-                let _ = tx.send(request).await;
-            } else {
-                println!("Failed to parse message: {}", text);
+
+            match serde_json::from_str::<WsMessage>(&text) {
+                Ok(request) => {
+                    let _ = msg_tx.send(request).await;
+                }
+                Err(_) => {
+                    println!("Failed to parse message: {}", text);
+                }
             }
         }
     }
 }
 
 async fn write(
-    mut sender: SplitSink<WebSocket, Message>,
-    mut rx: tokio::sync::mpsc::Receiver<Request>,
+    mut ws_sink: SplitSink<WebSocket, Message>,
+    mut msg_rx: tokio::sync::mpsc::Receiver<WsMessage>,
+    state: AppState,
 ) {
+    // store the channel subscriptions in-memory
     let mut subscriptions: Vec<String> = Vec::new();
-    let mut tx_stream: Option<Pin<Box<dyn Stream<Item = Transaction> + Send>>> = None;
+
+    // receiver for the transaction stream
+    let mut transaction_rx: Option<broadcast::Receiver<Transaction>> = None;
 
     loop {
         tokio::select! {
-            Some(request) = rx.recv() => {
+            // handle incoming messages
+            Some(request) = msg_rx.recv() => {
                 match request {
-                    // handle subscribe
-                    Request::Subscribe { params } => {
+                    // subscribe to a channel
+                    WsMessage::Subscribe { params } => {
                         if !subscriptions.contains(&params.channel) {
                             subscriptions.push(params.channel.clone());
 
                             match params.channel.as_str() {
                                 "transactions" => {
-                                    // start a stream for the channel
-                                    tx_stream = Some(stream_transactions());
+                                    // subscribe to the broadcast channel
+                                    transaction_rx = Some(state.broadcaster_tx.subscribe());
                                 }
                                 "heartbeat" => {
                                     // nothing to do here
@@ -100,26 +140,25 @@ async fn write(
                             }
                         }
                         // send ack
-                        let status = format!("Successfully subscribed to {} channel", params.channel);
-                        let ack = ChannelMsg::Heartbeat {
-                            data: Heartbeat {
-                                status
-                            },
-                        };
+                        let heartbeat = Heartbeat { status:format!("Successfully subscribed to {} channel", params.channel) };
+                        let ack = ChannelMsg::Heartbeat { data: heartbeat };
+
+                        // send the ack message to the client
                         if let Ok(serialized) = serde_json::to_string(&ack) {
-                            if sender.send(Message::Text(serialized.into())).await.is_err() {
+                            let msg = Message::Text(serialized.into());
+                            if ws_sink.send(msg).await.is_err() {
                                 break;
                             }
                         }
                     }
 
-                    // handle unsubscribe
-                    Request::Unsubscribe { params } => {
+                    // unsubscribe from a channel
+                    WsMessage::Unsubscribe { params } => {
                         subscriptions.retain(|c| c != &params.channel);
                         match params.channel.as_str() {
                             "transactions" => {
-                                // stop the stream
-                                tx_stream = None;
+                                // unsubscribe from the broadcast channel
+                                transaction_rx = None;
                             }
                             "heartbeat" => {
                                 // nothing to do here
@@ -127,14 +166,12 @@ async fn write(
                             _ => {}
                         }
 
-                        let status = format!("Successfully unsubscribed from {} channel", params.channel);
-                        let ack = ChannelMsg::Heartbeat {
-                            data: Heartbeat {
-                                status,
-                            },
-                        };
+                        let heartbeat = Heartbeat { status:format!("Successfully unsubscribed from {} channel", params.channel) };
+                        let ack = ChannelMsg::Heartbeat { data: heartbeat };
+
                         if let Ok(serialized) = serde_json::to_string(&ack) {
-                            if sender.send(Message::Text(serialized.into())).await.is_err() {
+                            let msg = Message::Text(serialized.into());
+                            if ws_sink.send(msg).await.is_err() {
                                 break;
                             }
                         }
@@ -142,30 +179,28 @@ async fn write(
                 }
             }
 
-            Some(transaction) = async {
-                match &mut tx_stream {
-                    Some(stream) => stream.next().await,
-                    None => None,
+            result = async {
+                match transaction_rx.as_mut() {
+                    Some(rx) => rx.recv().await.ok(),
+                    None => None
                 }
             } => {
-                let msg = ChannelMsg::Transactions {
-                    data: vec![transaction],
-                };
-                println!("Sending transactions: {:?}", msg);
-                if let Ok(serialized) = serde_json::to_string(&msg) {
-                    if sender.send(Message::Text(serialized.into())).await.is_err() {
-                        break;
+                if let Some(transaction) = result {
+                    let msg = ChannelMsg::Transactions { data: vec![transaction] };
+                    if let Ok(serialized) = serde_json::to_string(&msg) {
+                        let msg = Message::Text(serialized.into());
+                        if ws_sink.send(msg).await.is_err() {
+                            break;
+                        }
                     }
                 }
             }
-
-
         }
     }
 }
 
-// A stream that generates transactions
-fn stream_transactions() -> Pin<Box<dyn Stream<Item = Transaction> + Send>> {
+/// A stream that generates mock transactions
+fn stream_tx_from_mocks() -> impl Stream<Item = Transaction> + Send {
     let stream = futures::stream::unfold((), |()| async {
         tokio::time::sleep(Duration::from_millis(100)).await;
 

--- a/txapi/src/models.rs
+++ b/txapi/src/models.rs
@@ -10,12 +10,6 @@ pub enum Request {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
-pub struct SubscribeReq {
-    pub method: String,
-    pub params: SubscribeParams,
-}
-
-#[derive(Deserialize, Serialize, Debug)]
 pub struct SubscribeParams {
     pub channel: String,
 }
@@ -34,14 +28,11 @@ pub enum ChannelMsg {
 pub struct Transaction {
     pub id: String,
     pub timestamp: String,
-    #[serde(rename = "cc_number")]
     pub cc_number: String,
     pub category: String,
-    #[serde(rename = "amount_usd_cents")]
     pub amount_usd_cents: u64,
     pub latitude: f64,
     pub longitude: f64,
-    #[serde(rename = "country_iso")]
     pub country_iso: String,
     pub city: String,
 }

--- a/txapi/src/models.rs
+++ b/txapi/src/models.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct SubscribeReq {
+    pub method: String,
+    pub params: SubscribeParams,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct SubscribeParams {
+    pub channel: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(tag = "channel")]
+pub enum TxResponse {
+    #[serde(rename = "transactions")]
+    Transactions { data: Vec<Transaction> },
+
+    #[serde(rename = "heartbeat")]
+    Heartbeat { data: HeartbeatData },
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct Transaction {
+    pub id: String,
+    pub timestamp: String,
+    #[serde(rename = "cc_number")]
+    pub cc_number: String,
+    pub category: String,
+    #[serde(rename = "amount_usd_cents")]
+    pub amount_usd_cents: u64,
+    pub latitude: f64,
+    pub longitude: f64,
+    #[serde(rename = "country_iso")]
+    pub country_iso: String,
+    pub city: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct HeartbeatData {
+    pub status: String,
+}

--- a/txapi/src/models.rs
+++ b/txapi/src/models.rs
@@ -1,6 +1,15 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(tag = "method")]
+pub enum Request {
+    #[serde(rename = "subscribe")]
+    Subscribe { params: SubscribeParams },
+    #[serde(rename = "unsubscribe")]
+    Unsubscribe { params: SubscribeParams },
+}
+
+#[derive(Deserialize, Serialize, Debug)]
 pub struct SubscribeReq {
     pub method: String,
     pub params: SubscribeParams,
@@ -13,12 +22,12 @@ pub struct SubscribeParams {
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(tag = "channel")]
-pub enum TxResponse {
+pub enum ChannelMsg {
     #[serde(rename = "transactions")]
     Transactions { data: Vec<Transaction> },
 
     #[serde(rename = "heartbeat")]
-    Heartbeat { data: HeartbeatData },
+    Heartbeat { data: Heartbeat },
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -38,6 +47,6 @@ pub struct Transaction {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
-pub struct HeartbeatData {
+pub struct Heartbeat {
     pub status: String,
 }

--- a/txapi/src/models.rs
+++ b/txapi/src/models.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(tag = "method")]
-pub enum Request {
+pub enum WsMessage {
     #[serde(rename = "subscribe")]
     Subscribe { params: SubscribeParams },
     #[serde(rename = "unsubscribe")]
@@ -28,7 +28,7 @@ pub enum ChannelMsg {
     Heartbeat { data: Heartbeat },
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Transaction {
     pub id: String,
     pub timestamp: String,

--- a/txapi/src/models.rs
+++ b/txapi/src/models.rs
@@ -6,11 +6,15 @@ pub enum Request {
     #[serde(rename = "subscribe")]
     Subscribe { params: SubscribeParams },
     #[serde(rename = "unsubscribe")]
-    Unsubscribe { params: SubscribeParams },
+    Unsubscribe { params: UnsubscribeParams },
 }
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct SubscribeParams {
+    pub channel: String,
+}
+#[derive(Deserialize, Serialize, Debug)]
+pub struct UnsubscribeParams {
     pub channel: String,
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Implement a WebSocket API for streaming mocked credit card transactions.  Introduce `transactions` and `heartbeat` channels, and provide subscribe/unsubscribe functionality.  Generate mock transactions and broadcast them to subscribed clients.  Document the API and local setup in the README.

New Features:
- Implement a WebSockets API for streaming credit card transactions using `axum`.
- Introduce two channels: `transactions` for real-time transaction data and `heartbeat` for connection status.
- Create mock transaction data with randomized values for testing and development.
- Implement subscribe and unsubscribe functionality for managing channel subscriptions.
- Add support for broadcasting transactions to multiple subscribed clients.
- Implement a heartbeat mechanism to check the connection status.
- Define data models for transactions, heartbeat messages, and WebSocket requests/responses using `serde`.
- Set up a basic project structure with dependencies for `tokio`, `axum`, `serde`, and other necessary crates.
- Implement a simple `main` function to start the server and listen for incoming connections on port 9999.
- Add documentation for the API endpoints and data models in the README file.
- Include instructions for running the API locally using `make run`

Documentation:
- Document the new credit card transactions websocket API, including local setup instructions and API reference with examples for subscribing to channels, transaction responses, and heartbeat messages.
- Update the project title in the README to "Credit Card Transactions Websocket API" and expand the description to include an overview, channels information, and local setup instructions